### PR TITLE
不透明領域の候補を指定して、処理の負荷を減らせるよう実装

### DIFF
--- a/src/app/DrawRectGenerator.as
+++ b/src/app/DrawRectGenerator.as
@@ -56,6 +56,15 @@ package app {
          * @return
          */
         public function getDrawRect():Rectangle {
+
+            if (preCheckRanges != null) {
+                for each (var pcRange:Rectangle in preCheckRanges) {
+                    if (containsUntransparentPixel(pcRange) && !existUntransparentPixelOnOuterEdge(pcRange)) {
+                        return pcRange;
+                    }
+                }
+            }
+
             var rect:Rectangle = new Rectangle(0, 0, bitmapData.width, bitmapData.height);
             var checkRect:Rectangle = rect.clone();
 

--- a/src/app/DrawRectGenerator.as
+++ b/src/app/DrawRectGenerator.as
@@ -7,6 +7,7 @@ package app {
     public class DrawRectGenerator {
 
         private var bitmapData:BitmapData;
+        private var preCheckRanges:Vector.<Rectangle>;
         private var loopCounter:int = 0;
         private var interval:int = 0;
 
@@ -32,8 +33,18 @@ package app {
             interval = value;
         }
 
-        public function DrawRectGenerator(bmpData:BitmapData) {
+        /**
+         *
+         * @param bmpData 不透明な範囲を調べたい BitmapData を入力します。
+         * @param optionCheckRanges 不透明範囲の候補がある場合は入力します。
+         * このパラメーターを入力した場合は、この範囲を優先してチェックします。
+         */
+        public function DrawRectGenerator(bmpData:BitmapData, optionCheckRanges:Vector.<Rectangle> = null) {
             this.bitmapData = bmpData;
+
+            if (optionCheckRanges) {
+                this.preCheckRanges = optionCheckRanges;
+            }
         }
 
         /**

--- a/src/app/DrawRectGenerator.as
+++ b/src/app/DrawRectGenerator.as
@@ -179,3 +179,10 @@ package app {
         }
     }
 }
+
+        public function containsUntransparentPixel(rect:Rectangle):Boolean {
+            var pxs:Vector.<uint> = bitmapData.getVector(rect);
+            return pxs.some(function(item:uint, idx:int, v:Vector.<uint>):Boolean {
+                return (item != 0x0);
+            });
+        }

--- a/src/app/DrawRectGenerator.as
+++ b/src/app/DrawRectGenerator.as
@@ -177,8 +177,6 @@ package app {
         private function isTransparentPixel(pixelValue:uint):Boolean {
             return pixelValue <= 0x00ffffff;
         }
-    }
-}
 
         public function containsUntransparentPixel(rect:Rectangle):Boolean {
             var pxs:Vector.<uint> = bitmapData.getVector(rect);
@@ -186,3 +184,46 @@ package app {
                 return (item != 0x0);
             });
         }
+
+        /**
+         * 引数に入力した矩形の外周に不透明ピクセルが存在するかを取得します。
+         * @param rect
+         * @param numSkipPixel 外周のピクセルをチェックする際、この値だけチェックするピクセルをスキップします。
+         * 精度を落として処理を実行したいときに使用します。
+         * 例 1 で１つ飛ばし oxoxoxo 2 で２つ飛ばし oxxoxxoxxo
+         * @return
+         */
+        public function existUntransparentPixelOnOuterEdge(rect:Rectangle, numSkipPixel:int = 0):Boolean {
+            // 引数の rect をピッタリ覆う rect
+            var outerRect:Rectangle = new Rectangle(rect.x - 1, rect.y - 1, rect.width + 2, rect.height + 2);
+
+            var ranges:Vector.<Rectangle> = new Vector.<Rectangle>();
+            ranges.push(new Rectangle(outerRect.x, outerRect.y, outerRect.width, 1));
+            ranges.push(new Rectangle(outerRect.x, outerRect.bottom, outerRect.width, 1))
+            ranges.push(new Rectangle(outerRect.x, outerRect.y, 1, outerRect.height))
+            ranges.push(new Rectangle(outerRect.right, outerRect.y, 1, outerRect.height));
+
+            var existUntransparentPixel:Boolean = false;
+
+            for each (var r:Rectangle in ranges) {
+                var px:Vector.<uint> = bitmapData.getVector(r);
+
+                for (var i:int = 0; i < px.length; i++) {
+
+                    if (px[i] != 0x0) {
+                        existUntransparentPixel = true;
+                        break;
+                    }
+
+                    i += numSkipPixel;
+                }
+
+                if (existUntransparentPixel) {
+                    break;
+                }
+            }
+
+            return existUntransparentPixel;
+        }
+    }
+}

--- a/src/tests/TestDrawRectGenerator.as
+++ b/src/tests/TestDrawRectGenerator.as
@@ -87,3 +87,22 @@ package tests {
         }
     }
 }
+            testContainsUnTransparentPixel();
+
+        private function testContainsUnTransparentPixel():void {
+            var bmd:BitmapData = new BitmapData(40, 40, true, 0x0);
+            var drawRect:Rectangle = new Rectangle(10, 10, 10, 10);
+            bmd.fillRect(drawRect, 0xffffffff);
+
+            var bmdRect:Rectangle = new Rectangle(0, 0, bmd.width, bmd.height);
+
+            var ranges:Vector.<Rectangle> = new Vector.<Rectangle>();
+            ranges.push(new Rectangle(5, 5, 13, 13));
+            ranges.push(new Rectangle(30, 30, 20, 20));
+            ranges.push(new Rectangle(10, 10, 10, 10));
+            var rectGen:DrawRectGenerator = new DrawRectGenerator(bmd);
+
+            Assert.isTrue(rectGen.containsUntransparentPixel(new Rectangle(10, 10, 10, 10)));
+            Assert.isFalse(rectGen.containsUntransparentPixel(new Rectangle(30, 30, 10, 10)));
+
+        }

--- a/src/tests/TestDrawRectGenerator.as
+++ b/src/tests/TestDrawRectGenerator.as
@@ -57,6 +57,11 @@ package tests {
             var bmdRect:Rectangle = new Rectangle(0, 0, bmd.width, bmd.height);
             var rectGen:DrawRectGenerator = new DrawRectGenerator(bmd);
             Assert.isTrue(drawRect.equals(rectGen.getDrawRect()));
+
+            var v:Vector.<Rectangle> = new Vector.<Rectangle>();
+            v.push(drawRect);
+            var rectGen2:DrawRectGenerator = new DrawRectGenerator(bmd, v);
+            Assert.isTrue(drawRect.equals(rectGen2.getDrawRect()));
         }
 
         private function test4(param0:String):void {

--- a/src/tests/TestDrawRectGenerator.as
+++ b/src/tests/TestDrawRectGenerator.as
@@ -10,6 +10,9 @@ package tests {
             test2("左上に不透明領域が寄っている場合のテスト");
             test3("右下に不透明領域が寄っている場合のテスト");
             test4("loop回数を確認するテスト");
+
+            testContainsUnTransparentPixel();
+            testExistUntransparentPixelOnOuterEdge();
         }
 
         private function test():void {
@@ -85,9 +88,6 @@ package tests {
             Assert.isTrue(thridRectGen.LoopCounter < 540, "1600pxのうち 調査ピクセルを3/1程度まで減らす")
             Assert.isTrue(drawRect.equals(thridRectGen.getDrawRect()), "取得する矩形は想定と同じか");
         }
-    }
-}
-            testContainsUnTransparentPixel();
 
         private function testContainsUnTransparentPixel():void {
             var bmd:BitmapData = new BitmapData(40, 40, true, 0x0);
@@ -106,3 +106,27 @@ package tests {
             Assert.isFalse(rectGen.containsUntransparentPixel(new Rectangle(30, 30, 10, 10)));
 
         }
+
+        private function testExistUntransparentPixelOnOuterEdge():void {
+            var bmd:BitmapData = new BitmapData(40, 40, true, 0x0);
+            var drawRect:Rectangle = new Rectangle(10, 10, 10, 10);
+            bmd.fillRect(drawRect, 0xffffffff);
+
+            var bmdRect:Rectangle = new Rectangle(0, 0, bmd.width, bmd.height);
+
+            var ranges:Vector.<Rectangle> = new Vector.<Rectangle>();
+            ranges.push(drawRect);
+            var rectGen:DrawRectGenerator = new DrawRectGenerator(bmd);
+
+            // drawRect の外縁には、不透明ピクセルが存在しないので false 
+            // 精度を下げても結果は変わらないはず
+            Assert.isFalse(rectGen.existUntransparentPixelOnOuterEdge(drawRect, 0));
+            Assert.isFalse(rectGen.existUntransparentPixelOnOuterEdge(drawRect, 1));
+            Assert.isFalse(rectGen.existUntransparentPixelOnOuterEdge(drawRect, 2));
+
+            // 検索範囲を少し右にずらす。　不透明ピクセルがはみ出すはずなので true
+            var r:Rectangle = new Rectangle(12, 10, 20, 20);
+            Assert.isTrue(rectGen.existUntransparentPixelOnOuterEdge(r, 0));
+        }
+    }
+}


### PR DESCRIPTION
- 仕様変更 / DrawRectGenerator のコンストラクタの引数を変更
- 機能追加 / 指定領域に不透明ピクセルが含まれているかチェックするメソッドを追加
- 機能追加 / 指定した矩形の外周に不透明ピクセルがあるかを調べるメソッドを追加
- 機能追加 / 予め不透明領域を指定してループの回数を減らせるよう実装

close #2
